### PR TITLE
Removed conversion to angstroms

### DIFF
--- a/2021/CG-IDPs-Tesei-et-al/multi-chain/code/analyse.py
+++ b/2021/CG-IDPs-Tesei-et-al/multi-chain/code/analyse.py
@@ -165,8 +165,6 @@ def genDCD(residues,name,prot,temp,n_chains):
             top.add_bond(chain.atom(i),chain.atom(i+1))
 
     t = md.load(name+'/{:d}'.format(temp)+'/{:s}.gsd'.format(name), top)
-    t.xyz *= 10
-    t.unitcell_lengths *= 10
     lz = t.unitcell_lengths[0,2]
     edges = np.arange(-lz/2.,lz/2.,1)
     dz = (edges[1]-edges[0])/2.


### PR DESCRIPTION
In my mdtraj version (1.9.5), when reading a GSD (in nm) and saving a PDB (in angstroms), the conversion is made automatically. Please check that this behaviour has not changed.